### PR TITLE
Do not add SessionDuration to request when it is empty in configuration

### DIFF
--- a/background/script.js
+++ b/background/script.js
@@ -264,7 +264,7 @@ async function assumeRoleWithSAML(roleClaimValue, SAMLAssertion, SessionDuration
     RoleArn: RoleArn,
     SAMLAssertion: SAMLAssertion
   };
-  if (SessionDuration !== null) {
+  if (SessionDuration !== null && SessionDuration !== "") {
     params['DurationSeconds'] = SessionDuration;
   }
 
@@ -319,7 +319,7 @@ async function assumeRole(roleArn, roleSessionName, AccessKeyId, SecretAccessKey
     RoleArn: roleArn,
     RoleSessionName: roleSessionName
   };
-  if (SessionDuration !== null) {
+  if (SessionDuration !== null && SessionDuration !== "") {
     params['DurationSeconds'] = SessionDuration;
   }
   const command = new webpacksts.AWSAssumeRoleCommand(params);


### PR DESCRIPTION
Some request to specific AWS account failed when Session Duration parameters is set.
Allow to exclude this param when set empty.